### PR TITLE
Remove n9xx-xf86-video-fbdev-sgx package

### DIFF
--- a/config.py
+++ b/config.py
@@ -225,11 +225,6 @@ _jobs =  OrderedDict([
     ('icd2', {}),
 
     #
-    ('n9xx-xf86-video-fbdev-sgx', {
-        'arches': ['armhf'],
-    }),
-
-    #
     ('hildon-meta', {
         'arches': ['all'],
     }),

--- a/debian_glue
+++ b/debian_glue
@@ -121,16 +121,7 @@ if [ "$_mainrel" != "$release" ]; then
 	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${_mainrel} ${_mainrel} main contrib non-free"
 fi
 
-# for n900 specifics
-n900jobs="n9xx-xf86-video-fbdev-sgx"
 _curpkgname="$(echo $WORKSPACE | awk -F/ '{print $6}' | sed 's/-binaries$//')"
-_enablen900=false
-echo "$n900jobs" | grep -q "$_curpkgname" && _enablen900=true
-
-[ "$_enablen900" = true ] && {
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${release} n900"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${release} ${release} n900"
-}
 
 limajobs="mesa"
 _enablebackports=false


### PR DESCRIPTION
It's replaced by xf86-video-pvrsgx which doesn't need specific configuration.
```
<Wizzup> spinal84: probably this can go:
<Wizzup> n900jobs="n9xx-xf86-video-fbdev-sgx"
<Wizzup> at least the package string in there
```