### PR TITLE
dch_hook: fix expression calculation

### DIFF
--- a/dch_hook.sh
+++ b/dch_hook.sh
@@ -43,7 +43,7 @@ if [ -n "$_deb" ] ; then
     elif echo $_buildnum | grep -q "^${release_num}m7\.."; then
         echo "*** Found previous rebuild. Incrementing build number ***"
         _buildnum=$(echo $_buildnum | awk -F. '{print $NF}')
-        _buildnum="${release_num}m7.$[_buildnum + 1]"
+        _buildnum="${release_num}m7.$((_buildnum + 1))"
     else
         echo "*** Did not find previous builds. Assuming +${release_num}m7 ***"
         _buildnum="${release_num}m7"


### PR DESCRIPTION
Symptom:
LINE: xorg-server (2:1.19.2-2+1m7.$[_buildnum + 1]) unstable; urgency=medium
Should be:
LINE: xorg-server (2:1.19.2-2+1m7.2) unstable; urgency=medium

From bash(1) man page:
```
The format for arithmetic expansion is:
    $((expression))
The  old  format  $[expression]  is  deprecated  and will be removed in upcoming
versions of bash.
```

It seems that we already have the "upcoming" version of bash on our Jenkins server.

This breaks multiple rebuilds of the same package. An example:
https://phoenix.maemo.org/job/xorg-server-source/4/console

After merging this should be fixed.