### PR TITLE
debian_glue: fix Debian mirror for pbuilder jobs

### DIFF
--- a/debian_glue
+++ b/debian_glue
@@ -94,6 +94,10 @@ case "$distribution" in
     stretch*|buster*|bullseye*|bookworm*)
         # Debian
         MIRROR="http://deb.debian.org/debian"
+        # This option is needed for pbuilder to work nice in Devuan environment
+        PBUILDER_CONFIG=/etc/jenkins/debian_mirror
+        # Initialize it with command:
+        # echo 'MIRRORSITE=http://deb.debian.org/debian' > /etc/jenkins/debian_mirror
         ;;
     *)
         # Devuan


### PR DESCRIPTION
This change is needed to allow Debian packages to be built in Devuan environment. An example of the issue:
https://phoenix.maemo.org/job/xorg-server-binaries/architecture=armhf,label=armhf/2/console

With this commit and mirror configuration file in place it should be fixed.

To create the mirror configuration file for pbuilder, use this command:
`echo 'MIRRORSITE=http://deb.debian.org/debian' > /etc/jenkins/debian_mirror`

It should be done on every build server.