### PR TITLE
debian_glue: fix regression

### DIFF
--- a/debian_glue
+++ b/debian_glue
@@ -109,12 +109,12 @@ case "$distribution" in
         SECURITY_FOLDER="${distribution}-security"
 esac
 
-REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${MIRROR} ${distribution}-updates main contrib non-free"
+REPOSITORY_EXTRA="deb ${MIRROR} ${distribution}-updates main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src ${MIRROR} ${distribution}-updates main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
 
-REPOSITORY_EXTRA="deb http://maedevu.maemo.org/${release} ${release} main contrib non-free"
+REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${release} main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${release} ${release} main contrib non-free"
 
 # Pull in deps from the main repo when building -devel


### PR DESCRIPTION
https://phoenix.maemo.org/job/xorg-server-binaries/architecture=amd64,label=amd64/4/console

/etc/jenkins/debian_glue: line 112: REPOSITORY_EXTRA: unbound variable

Fixes: c8fbdd8d1 ("debian_glue: change repositories order")