### PR TITLE
Debian glue fixes

### DIFF
--- a/debian_glue
+++ b/debian_glue
@@ -73,17 +73,7 @@ REPOSITORY_KEYRING=/var/lib/jenkins/.gnupg/keyring.gpg
 # Default:
 # RELEASE_REPOSITORY="${REPOSITORY}/release/${release}"
 
-case "$release" in
-ascii*|beowulf*)
-	repo="leste"
-	;;
-extras)
-	repo="extras"
-	distribution="ascii"
-	;;
-esac
-
-RELEASE_REPOSITORY="${DEFAULT_REPOSITORY}/${repo}"
+RELEASE_REPOSITORY="${DEFAULT_REPOSITORY}/${release}"
 
 # Remove packages from a $release before processing incoming
 # This allows to rebuild and provide versions already existent
@@ -131,14 +121,14 @@ REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src ${MIRROR} ${distribution%-devel}-u
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
 
-REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${repo} ${distribution} main contrib non-free"
-REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${repo} ${distribution} main contrib non-free"
+REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${distribution} main contrib non-free"
+REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${release} ${distribution} main contrib non-free"
 
 # Pull in deps from the main repo when building -devel
 _dist=${distribution%-devel}
 if [ "$_dist" != "$distribution" ]; then
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${repo} ${_dist} main contrib non-free"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${repo} ${_dist} main contrib non-free"
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${_dist} main contrib non-free"
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${release} ${_dist} main contrib non-free"
 fi
 
 # Pull in deps from the main repo when building extras
@@ -158,8 +148,8 @@ if echo "$lima_jobs" | grep -qw "$_curpkgname"; then
 fi
 
 if echo "$n900_jobs" | grep -qw "$_curpkgname"; then
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${repo} ${distribution} n900"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${repo} ${distribution} n900"
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${distribution} n900"
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${release} ${distribution} n900"
 fi
 
 # Comma separated list of URLs with keys for extra repositories.

--- a/debian_glue
+++ b/debian_glue
@@ -117,24 +117,18 @@ case "$distribution" in
 esac
 
 REPOSITORY_EXTRA="deb ${MIRROR} ${distribution%-devel}-updates main contrib non-free"
-REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src ${MIRROR} ${distribution%-devel}-updates main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
-REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
-
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${distribution} main contrib non-free"
-REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${release} ${distribution} main contrib non-free"
 
 # Pull in deps from the main repo when building -devel
 _dist=${distribution%-devel}
 if [ "$_dist" != "$distribution" ]; then
 	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${_dist} main contrib non-free"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${release} ${_dist} main contrib non-free"
 fi
 
 # Pull in deps from the main repo when building extras
 if [ "$release" = "extras" ]; then
 	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/leste ${distribution} main contrib non-free"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/leste ${distribution} main contrib non-free"
 fi
 
 # Device specifics
@@ -144,12 +138,10 @@ _curpkgname="$(echo $WORKSPACE | awk -F/ '{print $6}' | sed 's/-binaries$//')"
 
 if echo "$lima_jobs" | grep -qw "$_curpkgname"; then
 	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${MIRROR} ${distribution}-backports main contrib non-free"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src ${MIRROR} ${distribution}-backports main contrib non-free"
 fi
 
 if echo "$n900_jobs" | grep -qw "$_curpkgname"; then
 	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${distribution} n900"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${release} ${distribution} n900"
 fi
 
 # Comma separated list of URLs with keys for extra repositories.

--- a/debian_glue
+++ b/debian_glue
@@ -141,11 +141,10 @@ if [ "$_dist" != "$distribution" ]; then
 	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${repo} ${_dist} main contrib non-free"
 fi
 
-# Pull in deps from the main repo when building -extras
-_mainrel=${distribution%-extras}
-if [ "$_mainrel" != "$distribution" ]; then
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${repo} ${_mainrel} main contrib non-free"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${repo} ${_mainrel} main contrib non-free"
+# Pull in deps from the main repo when building extras
+if [ "$release" = "extras" ]; then
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/leste ${distribution} main contrib non-free"
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/leste ${distribution} main contrib non-free"
 fi
 
 # Device specifics

--- a/debian_glue
+++ b/debian_glue
@@ -135,10 +135,10 @@ REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${repo} ${dis
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${repo} ${distribution} main contrib non-free"
 
 # Pull in deps from the main repo when building -devel
-_mainrel=${distribution%-devel}
-if [ "$_mainrel" != "$distribution" ]; then
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${repo} ${_mainrel} main contrib non-free"
-	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${repo} ${_mainrel} main contrib non-free"
+_dist=${distribution%-devel}
+if [ "$_dist" != "$distribution" ]; then
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${repo} ${_dist} main contrib non-free"
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb-src http://maedevu.maemo.org/${repo} ${_dist} main contrib non-free"
 fi
 
 # Pull in deps from the main repo when building -extras

--- a/debian_glue
+++ b/debian_glue
@@ -80,7 +80,7 @@ ascii*|beowulf*)
 	;;
 extras)
 	repo="extras"
-	release="ascii"
+	distribution="ascii"
 	;;
 esac
 

--- a/debian_glue
+++ b/debian_glue
@@ -6,14 +6,13 @@
 # signed and the keyring that holds the public key (REPOSITORY_KEYRING)
 # must be set.
 # Expected format: DEADBEEF
-case "$release" in
-extras)
-	KEY_ID=89F632F52BFE13EBBB2EBD0D2700BD8E6604EC2E
-	;;
-*)
+
+if ["$release" = "leste"]; then
 	KEY_ID=4AA81E3E026EFE82E47D6901545FEC4E0927F6FD
-	;;
-esac
+else
+	# extras
+	KEY_ID=89F632F52BFE13EBBB2EBD0D2700BD8E6604EC2E
+fi
 
 # If TRUNK_RELEASE is set then the package(s) of the repository
 # receiving the packages that are built will be copied to the


### PR DESCRIPTION
- fix 'extras' repo handling
- use 'release' variable instead of 'repo' (the meaning of this variables seems the same now)
- remove deb-src entries which are not needed for packages building

After these changes we should be able to schedule jobs with the following release/distribution pairs:
```
leste/ascii
leste/ascii-devel
leste/beowulf
extras/ascii
extras/beowulf
```