### PR TITLE
Rename suite: testing -> devel

### DIFF
--- a/debian_glue
+++ b/debian_glue
@@ -135,8 +135,8 @@ REPOSITORY_EXTRA="deb ${MIRROR} ${distribution%-devel}-updates main contrib non-
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${distribution} main contrib non-free"
 
-# Pull in deps from -devel when building -devel.
-if [ "$ENABLE_MAEMO_DEVEL" == "yes" ]; then
+# Pull in deps from -devel when building -devel
+if [ "$ENABLE_MAEMO_DEVEL" = "yes" ]; then
 	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${distribution}-devel main contrib non-free"
 fi
 

--- a/debian_glue
+++ b/debian_glue
@@ -118,7 +118,7 @@ if [ -z "$DEVUAN_BUILD" ]; then
         # Debian
         MIRROR="http://deb.debian.org/debian"
         SECURITY_MIRROR="http://security.debian.org/debian-security"
-        SECURITY_FOLDER="${distribution%-devel}/updates"
+        SECURITY_FOLDER="${distribution}/updates"
 
         # This option is needed for pbuilder to work nice in Devuan environment
         PBUILDER_CONFIG=/etc/jenkins/debian_mirror
@@ -128,10 +128,10 @@ else
         # Devuan
         MIRROR="http://pkgmaster.devuan.org/merged"
         SECURITY_MIRROR="${MIRROR}"
-        SECURITY_FOLDER="${distribution%-devel}-security"
+        SECURITY_FOLDER="${distribution}-security"
 fi
 
-REPOSITORY_EXTRA="deb ${MIRROR} ${distribution%-devel}-updates main contrib non-free"
+REPOSITORY_EXTRA="deb ${MIRROR} ${distribution}-updates main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/${release} ${distribution} main contrib non-free"
 
@@ -158,7 +158,7 @@ _curpkgname="$(echo $WORKSPACE | awk -F/ '{print $6}' | sed 's/-binaries$//')"
 if echo "$backports_jobs" | grep -qw "$_curpkgname"; then
 	case "$distribution" in
 	ascii*|stretch*)
-		REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${MIRROR} ${distribution%-devel}-backports main contrib non-free"
+		REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${MIRROR} ${distribution}-backports main contrib non-free"
 		;;
 	esac
 fi

--- a/debian_glue
+++ b/debian_glue
@@ -98,7 +98,23 @@ RELEASE_REPOSITORY="${DEFAULT_REPOSITORY}/${release}"
 # REPOSITORY_EXTRA=
 
 case "$distribution" in
-    stretch*|buster*|bullseye*|bookworm*)
+    stretch*)
+        PARENT_DISTRO=ascii
+        ;;
+    buster*)
+        PARENT_DISTRO=beowulf
+        ;;
+    bullseye*)
+        PARENT_DISTRO=
+        ;;
+    bookworm*)
+        PARENT_DISTRO=
+        ;;
+    *)
+        DEVUAN_BUILD=1
+esac
+
+if [ -z "$DEVUAN_BUILD" ]; then
         # Debian
         MIRROR="http://deb.debian.org/debian"
         SECURITY_MIRROR="http://security.debian.org/debian-security"
@@ -108,13 +124,12 @@ case "$distribution" in
         PBUILDER_CONFIG=/etc/jenkins/debian_mirror
         # Initialize it with command:
         # echo 'MIRRORSITE=http://deb.debian.org/debian' > /etc/jenkins/debian_mirror
-        ;;
-    *)
+else
         # Devuan
         MIRROR="http://pkgmaster.devuan.org/merged"
         SECURITY_MIRROR="${MIRROR}"
         SECURITY_FOLDER="${distribution%-devel}-security"
-esac
+fi
 
 REPOSITORY_EXTRA="deb ${MIRROR} ${distribution%-devel}-updates main contrib non-free"
 REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb ${SECURITY_MIRROR} ${SECURITY_FOLDER} main contrib non-free"
@@ -128,6 +143,11 @@ fi
 # Pull in deps from the main repo when building extras
 if [ "$release" = "extras" ]; then
 	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/leste ${distribution} main contrib non-free"
+fi
+
+# Pull in deps from main repo when building for Debian
+if [ -n "$PARENT_DISTRO" ]; then
+	REPOSITORY_EXTRA="${REPOSITORY_EXTRA},deb http://maedevu.maemo.org/leste ${PARENT_DISTRO} main contrib non-free"
 fi
 
 # Device specifics

--- a/reprepro/extras/conf/distributions
+++ b/reprepro/extras/conf/distributions
@@ -1,5 +1,5 @@
 Origin: Maemo Leste Extras
-Label: Maemo Leste Extras
+Label: extras-devuan
 Suite: stable
 Codename: ascii
 Architectures: amd64 armhf arm64 source
@@ -8,7 +8,7 @@ Description: Maemo Leste Extras (Devuan Ascii)
 SignWith: 89F632F52BFE13EBBB2EBD0D2700BD8E6604EC2E
 
 Origin: Maemo Leste Extras
-Label: Maemo Leste Extras
+Label: extras-devuan
 Suite: unstable
 Codename: beowulf
 Architectures: amd64 armhf arm64 source
@@ -18,7 +18,7 @@ SignWith: 89F632F52BFE13EBBB2EBD0D2700BD8E6604EC2E
 
 
 Origin: Maemo Leste Extras
-Label: Maemo Leste Extras
+Label: extras-debian
 Suite: stable
 Codename: stretch
 Architectures: amd64 armhf arm64 source
@@ -27,7 +27,7 @@ Description: Maemo Leste Extras (Debian Stretch)
 SignWith: 89F632F52BFE13EBBB2EBD0D2700BD8E6604EC2E
 
 Origin: Maemo Leste Extras
-Label: Maemo Leste Extras
+Label: extras-debian
 Suite: unstable
 Codename: buster
 Architectures: amd64 armhf arm64 source

--- a/reprepro/leste/conf/distributions
+++ b/reprepro/leste/conf/distributions
@@ -9,7 +9,7 @@ SignWith: 4AA81E3E026EFE82E47D6901545FEC4E0927F6FD
 
 Origin: Maemo Leste
 Label: Maemo Leste
-Suite: testing
+Suite: devel
 Codename: ascii-devel
 Architectures: amd64 armhf arm64 source
 Components: main contrib non-free n900 droid4 n9 n950 lima pinephone

--- a/reprepro/leste/conf/distributions
+++ b/reprepro/leste/conf/distributions
@@ -1,5 +1,5 @@
 Origin: Maemo Leste
-Label: Maemo Leste
+Label: leste-devuan
 Suite: stable
 Codename: ascii
 Architectures: amd64 armhf arm64 source
@@ -8,7 +8,7 @@ Description: Maemo Leste (Devuan Ascii)
 SignWith: 4AA81E3E026EFE82E47D6901545FEC4E0927F6FD
 
 Origin: Maemo Leste
-Label: Maemo Leste
+Label: leste-devuan
 Suite: devel
 Codename: ascii-devel
 Architectures: amd64 armhf arm64 source
@@ -17,7 +17,7 @@ Description: Maemo Leste Devel (Devuan Ascii)
 SignWith: 4AA81E3E026EFE82E47D6901545FEC4E0927F6FD
 
 Origin: Maemo Leste
-Label: Maemo Leste
+Label: leste-devuan
 Suite: unstable
 Codename: beowulf
 Architectures: amd64 armhf arm64 source
@@ -26,7 +26,7 @@ Description: Maemo Leste (Devuan Beowulf)
 SignWith: 4AA81E3E026EFE82E47D6901545FEC4E0927F6FD
 
 Origin: Maemo Leste
-Label: Maemo Leste
+Label: leste-devuan
 Suite: experimental
 Codename: beowulf-devel
 Architectures: amd64 armhf arm64 source
@@ -35,7 +35,7 @@ Description: Maemo Leste Devel (Devuan Beowulf)
 SignWith: 4AA81E3E026EFE82E47D6901545FEC4E0927F6FD
 
 Origin: Maemo Leste
-Label: Maemo Leste
+Label: leste-debian
 Suite: stable
 Codename: stretch
 Architectures: amd64 armhf arm64 source
@@ -44,7 +44,7 @@ Description: Maemo Leste (Debian Stretch)
 SignWith: 4AA81E3E026EFE82E47D6901545FEC4E0927F6FD
 
 Origin: Maemo Leste
-Label: Maemo Leste
+Label: leste-debian
 Suite: unstable
 Codename: buster
 Architectures: amd64 armhf arm64 source

--- a/xmls/binaries-all.xml
+++ b/xmls/binaries-all.xml
@@ -64,11 +64,10 @@
     <hudson.tasks.Shell>
       <command>export BUILD_ONLY=true
 
-if echo &quot;${distribution}&quot; | grep -q -- &apos;-devel$&apos; -; then
-    __dist=&quot;$(echo &quot;${distribution}&quot; | sed &apos;s,-devel,,&apos;)&quot;
+__dist=${distribution%-devel}
+if [ &quot;$distribution&quot; != &quot;$__dist&quot; ]; then
     export ENABLE_MAEMO_DEVEL=yes
 else
-    __dist=&quot;${distribution}&quot;
     export ENABLE_MAEMO_DEVEL=no
 fi
 

--- a/xmls/binaries-arch.xml
+++ b/xmls/binaries-arch.xml
@@ -78,11 +78,10 @@
     <hudson.tasks.Shell>
       <command>export BUILD_ONLY=true
 
-if echo &quot;${distribution}&quot; | grep -q -- &apos;-devel$&apos; -; then
-    __dist=&quot;$(echo &quot;${distribution}&quot; | sed &apos;s,-devel,,&apos;)&quot;
+__dist=${distribution%-devel}
+if [ &quot;$distribution&quot; != &quot;$__dist&quot; ]; then
     export ENABLE_MAEMO_DEVEL=yes
 else
-    __dist=&quot;${distribution}&quot;
     export ENABLE_MAEMO_DEVEL=no
 fi
 


### PR DESCRIPTION
It appears that suite is displayed when the user does 'apt list --upgradable'

The output might look like this:
```
devuan-droid4 ~ # apt list --upgradable
Listing... Done
libglib2.0-0/testing 2.50.3-3+1m7.2 armhf [upgradable from: 2.50.3-2+deb9u2]
libglib2.0-bin/testing 2.50.3-3+1m7.2 armhf [upgradable from: 2.50.3-2+deb9u2]
libglib2.0-data/testing 2.50.3-3+1m7.2 all [upgradable from: 2.50.3-2+deb9u2]
libglib2.0-dev/testing 2.50.3-3+1m7.2 armhf [upgradable from: 2.50.3-2+deb9u2]
...
```

The user may be confused by the word "testing" next to the package
names.

Let's replace it with "devel" so that we don't have to guess what the
source of the package is.