### PR TITLE
debian_glue: fix error: DEVUAN_BUILD: unbound variable

### DIFF
--- a/debian_glue
+++ b/debian_glue
@@ -97,6 +97,8 @@ RELEASE_REPOSITORY="${DEFAULT_REPOSITORY}/${release}"
 # Default:
 # REPOSITORY_EXTRA=
 
+DEVUAN_BUILD=
+
 case "$distribution" in
     stretch*)
         PARENT_DISTRO=ascii


### PR DESCRIPTION
An issue example: https://phoenix.maemo.org/job/dsme-source/16/console